### PR TITLE
Fixing #6 for querying nested collections like URI/customers(1)/Orders(2)

### DIFF
--- a/odata_api/src/main/scala/com/sdl/odata/api/parser/ODataUriUtil.scala
+++ b/odata_api/src/main/scala/com/sdl/odata/api/parser/ODataUriUtil.scala
@@ -16,10 +16,10 @@
 package com.sdl.odata.api.parser
 
 import com.sdl.odata.api.ODataNotImplementedException
-import com.sdl.odata.api.edm.model.{ActionImport, Function, Action, EntityDataModel, EntityType, FunctionImport, NavigationProperty}
+import com.sdl.odata.api.edm.model.{Action, ActionImport, EntityDataModel, EntityType, Function, FunctionImport, NavigationProperty}
 import com.sdl.odata.util.PrimitiveUtil
 import com.sdl.odata.util.edm.EntityDataModelUtil
-import com.sdl.odata.util.edm.EntityDataModelUtil.{getAndCheckAction, getAndCheckActionImport, getAndCheckEntitySet, getAndCheckEntityType, getAndCheckFunction, getAndCheckFunctionImport, getAndCheckSingleton, getAndCheckStructuredType, isCollection, isSingletonEntity, pluralize}
+import com.sdl.odata.util.edm.EntityDataModelUtil.{getAndCheckAction, getAndCheckActionImport, getAndCheckEntitySet, getAndCheckEntityType, getAndCheckFunction, getAndCheckFunctionImport, getAndCheckSingleton, getAndCheckStructuredType, isCollection, isSingletonEntity}
 
 /**
  * Target type of an URI: the type of entity that will be the result of a query for an URI.
@@ -257,7 +257,8 @@ object ODataUriUtil {
     }
 
     def getContextFromSubPath(typeName: String, pathSegment: Option[PathSegment], acc: String, keyPredicateValue: Option[String]): Option[String] = pathSegment match {
-      case Some(PropertyPath(propertyName, subPath)) => getContextFromSubPath(typeName, subPath, s"$acc/$propertyName", keyPredicateValue)
+      case Some(PropertyPath(propertyName, Some(EntityCollectionPath(derivedType, subPath)))) => getContextFromSubPath(propertyName, subPath, s"$acc/", keyPredicateValue)
+      case Some(PropertyPath(propertyName, subPath)) => getContextFromSubPath(propertyName, subPath, s"$acc/$propertyName", keyPredicateValue)
       case Some(ComplexPath(derivedType, subPath)) => handleEntityPath(typeName, derivedType, subPath, acc, keyPredicateValue)
       case Some(EntityPath(derivedType, subPath)) => handleEntityPath(typeName, derivedType, subPath, acc, keyPredicateValue)
       case Some(KeyPredicatePath(_, None)) => getContextFromSubPath(typeName, None, s"$acc$typeName/$ENTITY", keyPredicateValue)

--- a/odata_parser/src/test/java/com/sdl/odata/parser/ParserOrderTest.java
+++ b/odata_parser/src/test/java/com/sdl/odata/parser/ParserOrderTest.java
@@ -75,8 +75,8 @@ public class ParserOrderTest extends ParserTestSuite {
     }
 
     @Test
-    public void testFirstCustomerFirstProductFirstOrderLine() throws ODataException {
-        uri = parser.parseUri(SERVICE_ROOT + "Customers(0)/Orders(0)/orderLines(0)", model);
+    public void testFirstCustomerSecondProductThirdOrderLine() throws ODataException {
+        uri = parser.parseUri(SERVICE_ROOT + "Customers(0)/Orders(1)/orderLines(2)", model);
         assertNotNull(uri);
         RelativeUri relative = uri.relativeUri();
         assertNotNull(relative);
@@ -84,6 +84,8 @@ public class ParserOrderTest extends ParserTestSuite {
         assertTrue(relative.toString().contains("Customers"));
         assertTrue(relative.toString().contains("NumberLiteral(0)"));
         assertTrue(relative.toString().contains("Orders"));
+        assertTrue(relative.toString().contains("NumberLiteral(1)"));
         assertTrue(relative.toString().contains("orderLines"));
+        assertTrue(relative.toString().contains("NumberLiteral(2)"));
     }
 }

--- a/odata_parser/src/test/java/com/sdl/odata/parser/ParserOrderTest.java
+++ b/odata_parser/src/test/java/com/sdl/odata/parser/ParserOrderTest.java
@@ -62,4 +62,28 @@ public class ParserOrderTest extends ParserTestSuite {
         }
     }
 
+    @Test
+    public void testFirstCustomerProducts() throws ODataException {
+        uri = parser.parseUri(SERVICE_ROOT + "Customers(0)/Orders", model);
+        assertNotNull(uri);
+        RelativeUri relative = uri.relativeUri();
+        assertNotNull(relative);
+        assertTrue(relative instanceof ResourcePathUri);
+        assertTrue(relative.toString().contains("Customers"));
+        assertTrue(relative.toString().contains("NumberLiteral(0)"));
+        assertTrue(relative.toString().contains("Orders"));
+    }
+
+    @Test
+    public void testFirstCustomerFirstProductFirstOrderLine() throws ODataException {
+        uri = parser.parseUri(SERVICE_ROOT + "Customers(0)/Orders(0)/orderLines(0)", model);
+        assertNotNull(uri);
+        RelativeUri relative = uri.relativeUri();
+        assertNotNull(relative);
+        assertTrue(relative instanceof ResourcePathUri);
+        assertTrue(relative.toString().contains("Customers"));
+        assertTrue(relative.toString().contains("NumberLiteral(0)"));
+        assertTrue(relative.toString().contains("Orders"));
+        assertTrue(relative.toString().contains("orderLines"));
+    }
 }

--- a/odata_parser/src/test/scala/com/sdl/odata/parser/ODataUriUtilTest.scala
+++ b/odata_parser/src/test/scala/com/sdl/odata/parser/ODataUriUtilTest.scala
@@ -251,6 +251,10 @@ class ODataUriUtilTest extends FunSuite with ParserTestHelpers {
         Some("http://localhost:8080/odata.svc/$metadata#Customers/$entity"))
 
     assert(
+      getContextUrl(parser.parseUri("http://localhost:8080/odata.svc/Customers('test123')/Orders?$format=json")) ===
+        Some("http://localhost:8080/odata.svc/$metadata#Customers('test123')/Orders"))
+
+    assert(
       getContextUrl(parser.parseUri("http://localhost:8080/odata.svc/ComplexKeySamples(id=15,name='ComplexKey',period=duration'P3Y30M30D')?$format=json")) ===
         Some("http://localhost:8080/odata.svc/$metadata#ComplexKeySamples/$entity"))
   }
@@ -300,6 +304,17 @@ class ODataUriUtilTest extends FunSuite with ParserTestHelpers {
   test("context url => collection field of an entity set") {
     assert(getContextUrl(parser.parseUri("http://localhost:8080/odata.svc/Customers(1)/Orders")) ===
       Some("http://localhost:8080/odata.svc/$metadata#Customers(1)/Orders"))
+
+    assert(getContextUrl(parser.parseUri("http://localhost:8080/odata.svc/Customers(1)/Orders(2)/orderLines")) ===
+      Some("http://localhost:8080/odata.svc/$metadata#Customers(1)/Orders(2)/orderLines"))
+  }
+
+  test("context url => entity of an entity set") {
+    assert(getContextUrl(parser.parseUri("http://localhost:8080/odata.svc/Customers(1)/Orders(123)")) ===
+      Some("http://localhost:8080/odata.svc/$metadata#Customers(1)/Orders/$entity"))
+
+    assert(getContextUrl(parser.parseUri("http://localhost:8080/odata.svc/Customers(1)/Orders(123)/orderLines(5)")) ===
+      Some("http://localhost:8080/odata.svc/$metadata#Customers(1)/Orders(123)/orderLines/$entity"))
   }
 
   test("context url => simple property") {


### PR DESCRIPTION
`getContextFromSubPath` was missing match case for `EntityCollectionPath`.
Adding case for `PropertyPath(EntityCollectionPath)` though, so property name won't appear twice in the context URL.
Enhanced test suite with cases for possible URLs.

Tested with odata-examples, now data returned correctly for URIs like
URI/Topic('topic-1')/Message('msg-1')

Correct @odata.context is inserted in the message body as bonus.

Consulted [odata v4 doc](http://docs.oasis-open.org/odata/odata/v4.0/errata02/os/complete/part1-protocol/odata-v4.0-errata02-os-part1-protocol-complete.html#_Toc406398268)  for proper context URL.