### PR TITLE
TCD-28: fixed line separator issue in tests

### DIFF
--- a/odata_client_tracing/src/test/java/com/sdl/odata/client/caller/TracingEndpointCallerTest.java
+++ b/odata_client_tracing/src/test/java/com/sdl/odata/client/caller/TracingEndpointCallerTest.java
@@ -44,6 +44,7 @@ import java.util.Properties;
 import static com.sdl.odata.api.service.MediaType.JSON;
 import static com.sdl.odata.client.ODataClientConstants.WebService.CLIENT_SERVICE_PROXY_HOST_NAME;
 import static com.sdl.odata.client.ODataClientConstants.WebService.CLIENT_SERVICE_PROXY_PORT;
+import static java.lang.System.lineSeparator;
 import static java.net.HttpURLConnection.HTTP_CLIENT_TIMEOUT;
 import static java.net.HttpURLConnection.HTTP_FORBIDDEN;
 import static java.net.HttpURLConnection.HTTP_UNAUTHORIZED;
@@ -86,7 +87,7 @@ public class TracingEndpointCallerTest {
     public void callEndpoint() throws ODataClientException, MalformedURLException {
         String response = caller.callEndpoint(singletonMap("Accept", JSON.getType()), new URL(basePath + RESPONSE));
         String expected = URLTestUtils.loadTextFile(RESPONSE);
-        assertThat(response, equalTo(expected.substring(0, expected.lastIndexOf("\n"))));
+        assertThat(response, equalTo(expected.substring(0, expected.lastIndexOf(lineSeparator()))));
     }
 
     @Test
@@ -119,7 +120,7 @@ public class TracingEndpointCallerTest {
         String response = proxifiedCaller.callEndpoint(emptyMap(), new URL(basePath + RESPONSE));
         String result = URLTestUtils.loadTextFile(RESPONSE);
 
-        assertThat(response, equalTo(result.substring(0, result.lastIndexOf('\n'))));
+        assertThat(response, equalTo(result.substring(0, result.lastIndexOf(lineSeparator()))));
     }
 
     @Test
@@ -144,7 +145,7 @@ public class TracingEndpointCallerTest {
     public void okPutEntity() throws MalformedURLException, ODataClientException {
         String body = URLTestUtils.loadTextFile(RESPONSE);
         String result = caller.doPutEntity(emptyMap(), new URL(basePath + RESPONSE), body, JSON);
-        assertThat(body.substring(0, body.lastIndexOf('\n')), equalTo(result));
+        assertThat(body.substring(0, body.lastIndexOf(lineSeparator())), equalTo(result));
     }
 
     @Test


### PR DESCRIPTION
Fixed tests for different platforms (line separators)