### PR TITLE
Fix invalid data format response message

### DIFF
--- a/odata_renderer/src/main/java/com/sdl/odata/unmarshaller/json/core/JsonParserUtils.java
+++ b/odata_renderer/src/main/java/com/sdl/odata/unmarshaller/json/core/JsonParserUtils.java
@@ -96,14 +96,18 @@ public final class JsonParserUtils {
             // Handle Java.Time types which have parse method
             try {
                 return wrappedType.getMethod("parse", String.class).invoke(null, fieldValue);
-            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            } catch (IllegalAccessException | NoSuchMethodException e) {
                 throw new ODataUnmarshallingException(e.getMessage(), e);
+            } catch (InvocationTargetException e) {
+                throw wrapInvocationTargetException(e);
             }
         } else if (hasMethod(wrappedType, "valueOf", String.class)) {
             try {
                 return wrappedType.getMethod("valueOf", String.class).invoke(null, fieldValue);
-            } catch (IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            } catch (IllegalAccessException | NoSuchMethodException e) {
                 throw new ODataUnmarshallingException(e.getMessage(), e);
+            } catch (InvocationTargetException e) {
+                throw wrapInvocationTargetException(e);
             }
         } else if (wrappedType == ZonedDateTime.class) {
             return ZonedDateTime.parse(fieldValue);
@@ -135,4 +139,12 @@ public final class JsonParserUtils {
         return type != null && type instanceof StructuredType;
     }
 
+    private static ODataUnmarshallingException wrapInvocationTargetException(
+        InvocationTargetException e) {
+        if (e.getCause() != null) {
+            return new ODataUnmarshallingException(e.getCause().getMessage(), e.getCause());
+        } else {
+            return new ODataUnmarshallingException(e.getMessage(), e);
+        }
+    }
 }

--- a/odata_renderer/src/test/java/com/sdl/odata/unmarshaller/json/core/JsonParserUtilsTest.java
+++ b/odata_renderer/src/test/java/com/sdl/odata/unmarshaller/json/core/JsonParserUtilsTest.java
@@ -1,0 +1,56 @@
+/**
+ * Copyright (c) 2014 All Rights Reserved by the SDL Group.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.sdl.odata.unmarshaller.json.core;
+
+import com.sdl.odata.api.unmarshaller.ODataUnmarshallingException;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+/**
+ * Test for JsonParserUtils.
+ */
+public class JsonParserUtilsTest {
+
+    /**
+     * Used for tests that expect exception when parsing field.
+     */
+    @Rule
+    public ExpectedException thrown = ExpectedException.none();
+
+    private static final String BAD_VALUE = "BAD_VALUE";
+
+    @Test
+    public void testIncorrectEnumValue() throws ODataUnmarshallingException {
+        thrown.expect(ODataUnmarshallingException.class);
+        thrown.expectMessage(BAD_VALUE);
+        JsonParserUtils.getAppropriateFieldValue(TestEnum.class, BAD_VALUE);
+    }
+
+    @Test
+    public void testIncorrectIntegerValue() throws ODataUnmarshallingException {
+        thrown.expect(ODataUnmarshallingException.class);
+        thrown.expectMessage(BAD_VALUE);
+        JsonParserUtils.getAppropriateFieldValue(Integer.class, BAD_VALUE);
+    }
+
+    /**
+     * Test Enum to test invalid data format case.
+     */
+    enum TestEnum {
+        TEST
+    }
+}


### PR DESCRIPTION
Suggestion to make error message more verbose when client submits incorrect data:

The issue was:
- Prepare request to update/create item
- Set incorrect propety value (e.g. bad number or non-existing enum value)
Example request (assuming that "someIncorrectValue" is not allowed for "someEnumProperty"): 
`curl -X POST --header "Content-type:Application/JSON" --data-binary "{\"id\":\"someId\", \"someEnumProperty\":\"someIncorrectValue\"}" http://localhost:8080/sdlexamle.svc/Entities`

The result will be:
{"error":{"code":"2000","message":"null"}}

Expected result:
message should explain why request was failed.

The fix is:
- Added special handling for InvocationTargetException.
- Added unit tests to demonstrate original issue and proof the fix.