### PR TITLE
UDP-5989: Spring 5 upgrade

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -108,7 +108,7 @@
         <scalatest.version>3.0.5</scalatest.version>
         <servlet-api.version>3.1.0</servlet-api.version>
         <slf4j.version>1.7.25</slf4j.version>
-        <spring.version>5.1.3.RELEASE</spring.version>
+        <spring.version>5.0.9.RELEASE</spring.version>
         <spring-boot.version>1.5.16.RELEASE</spring-boot.version>
         <tomcat.version>8.5.34</tomcat.version>
         <typesafe-config.version>1.3.1</typesafe-config.version>


### PR DESCRIPTION
Spring 5 needs to be downgraded to 5.0.9 due to deprecation of YamlProcessor$StrictMapAppenderConstructor