### PR TITLE
Update pluginRepository in pom to https

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -432,7 +432,7 @@
         <pluginRepository>
             <id>central</id>
             <name>Maven Plugin Repository</name>
-            <url>http://repo1.maven.org/maven2</url>
+            <url>https://repo1.maven.org/maven2</url>
             <layout>default</layout>
             <snapshots>
                 <enabled>false</enabled>


### PR DESCRIPTION
I needed this change in order to run `mvn clean install` locally.

It's possible I'm the first person with a blank-slate Maven history (I primarily use sbt as my build tool) to locally build this project since Maven Central went HTTPS-only.